### PR TITLE
CV Integration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,13 +110,6 @@ To access the shell within the container:
 docker run -it --rm astroplate ash
 ```
 
-<!-- reporting issue -->
-
-## 🐞 Reporting Issues
-
-We use GitHub Issues as the official bug tracker for this Template. Please Search [existing issues](https://github.com/zeon-studio/astroplate/issues). It’s possible someone has already reported the same problem.
-If your problem or idea has not been addressed yet, feel free to [open a new issue](https://github.com/zeon-studio/astroplate/issues).
-
 <!-- licence -->
 
 ## 📝 License
@@ -127,6 +120,16 @@ Copyright (c) 2023 - Present, Designed & Developed by [Zeon Studio](https://zeon
 
 **Image license:** The images are only for demonstration purposes. They have their license, we don't have permission to share those images.
 
-## 💻 Need Custom Development Services?
+# Customization Notes
 
-If you need a custom theme, theme customization, or complete website development services from scratch you can [Hire Us](https://zeon.studio/).
+Here I will document how I (Michael Alonge) customized the Astroplate template to my personal website.
+
+## CV
+
+The CV page combines a few key components:
+
+- A JSON file that contains my professional information following the [JSON Resume standard](https://jsonresume.org/)
+- A HTML/CSS typeset resume template by [Min–Zhong John Lu](https://github.com/mnjul/html-resume?tab=readme-ov-file)
+- The astroplate template
+
+The resume data is stored in `src/config/cv.json` and is treated as a configuration. This decouples the resume data from the resume template. Then I extended and customized the HTML/CSS template provided by Min–Zhong John Lu in `src/styles/cv.css` and `src/pages/cv.astro` to create a modern, print-optimized resume. By default, the `cv` page behaves like a normal website page and all of my resume content is embedded directly in the page. However, I added a print button to the page that allows the user to print the resume to a formatted PDF.

--- a/src/config/cv.json
+++ b/src/config/cv.json
@@ -6,7 +6,7 @@
       "email": "malonge11@gmail.com",
       "phone": null,
       "url": "https://michaelalonge.com",
-      "summary": "Software engineer and computational biologist with 10+ years of experience designing and leading scalable data platforms. Ph.D. in Computer Science from Johns Hopkins with a strong publication record in top journals including Nature, Science, and Cell. Skilled in cloud-native architecture, data engineering, and bioinformatics, with a proven ability to bridge genomics and software engineering to build reliable, production-ready systems for biotech.",
+      "summary": "Software engineer and computational biologist with 10+ years of experience designing and leading scalable genomics analysis. Ph.D. in Computer Science from Johns Hopkins with a strong publication record in top journals including Cell, Science, and Nature. Skilled in cloud-native architecture, data engineering, and bioinformatics, with a proven ability to bridge genomics and software engineering to build reliable, production-ready systems for biotech.",
       "location": {
         "address": null,
         "postalCode": "90036",

--- a/src/config/cv.json
+++ b/src/config/cv.json
@@ -1,0 +1,350 @@
+{
+    "basics": {
+      "name": "Michael Alonge",
+      "label": "Software Engineer | Computational Biologist | Team Lead",
+      "image": "/images/profile.png",
+      "email": "malonge11@gmail.com",
+      "phone": "+1 (831) 201-2788",
+      "url": "https://michaelalonge.com",
+      "summary": "Software engineer and computational biologist with 10+ years of experience designing and leading scalable data platforms. Ph.D. in Computer Science from Johns Hopkins with a strong publication record in top journals including Nature, Science, and Cell. Skilled in cloud-native architecture, data engineering, and bioinformatics, with a proven ability to bridge genomics and software engineering to build reliable, production-ready systems for biotech.",
+      "location": {
+        "address": "",
+        "postalCode": "90036",
+        "city": "Los Angeles",
+        "countryCode": "US",
+        "region": "CA"
+      },
+      "profiles": [
+        {
+          "network": "LinkedIn",
+          "username": "michael-alonge",
+          "url": "https://www.linkedin.com/in/michael-alonge-1348a973/"
+        },
+        {
+          "network": "GitHub",
+          "username": "malonge",
+          "url": "https://github.com/malonge"
+        },
+        {
+          "network": "Google Scholar",
+          "username": "5zUWawIAAAAJ",
+          "url": "https://scholar.google.com/citations?user=5zUWawIAAAAJ&hl=en"
+        }
+      ]
+    },
+    "work": [
+      {
+        "name": "Ohalo Genetics",
+        "position": "Lead Software Engineer, Computational Biology",
+        "url": "https://ohalo.com",
+        "startDate": "2025-03-16",
+        "endDate": "Present",
+        "summary": "Leading the design and development of Ohalo’s genomics data platform, enabling automated and scalable management of genomics data to support breeding, gene editing, and IP strategy. Serving as the company’s lead subject matter expert in genomics and bioinformatics, with an emphasis on scalable and accurate genotyping methods.",
+        "highlights": [
+          "Architect and lead development of Ohalo’s genomics data platform for large-scale breeding and gene editing programs",
+          "Manage and mentor a cross-functional team of software engineers and bioinformaticians",
+          "Set strategic direction for genomics and bioinformatics in support of IP and product development"
+        ]
+      },
+      {
+        "name": "Ohalo Genetics",
+        "position": "Lead Computational Biologist",
+        "url": "https://ohalo.com",
+        "startDate": "2021-12-06",
+        "endDate": "2025-03-16",
+        "summary": "Directed bioinformatics and genomics analysis for Ohalo’s breeding and gene editing programs, with a focus on scalable genotyping methods and intellectual property development.",
+        "highlights": [
+          "Led bioinformatics strategy and analysis for Ohalo’s Boosted Breeding™ foundational patents",
+          "Developed Ohalo’s first scalable genotyping pipeline, supporting breeding and gene editing initiatives",
+          "Directed genomics analysis for all programs, including Ohalo’s ‘FruitionOne’ Almond program"
+        ]
+      },
+      {
+        "name": "Johns Hopkins University",
+        "position": "Ph.D. Student, Computer Science",
+        "url": "https://cs.jhu.edu",
+        "startDate": "2017-08-31",
+        "endDate": "2021-12-03",
+        "summary": "Ph.D. in Computer Science under Professor Michael Schatz, focused on genome assembly and structural variation in humans and plants. Served as teaching assistant for ‘Computational Genomics: Sequences’ with Professor Ben Langmead.",
+        "highlights": [
+          "Published multiple first-author papers in journals including Cell and Science",
+          "Invited speaker at a Galaxy webinar and the Boyce Thompson Institute for Plant Research"
+        ]
+      },
+      {
+        "name": "Driscoll's",
+        "position": "Research Associate I and II: Computational Biology",
+        "url": "https://www.driscolls.com/",
+        "startDate": "2014-11-01",
+        "endDate": "2017-08-01",
+        "summary": "Led computational biology projects to support plant breeding and molecular biology, with a focus on establishing reference genome assemblies. Contributed to wet-lab protocols and plant phenotyping.",
+        "highlights": [
+          "Generated reference genome assemblies to enable downstream genomics analyses",
+          "Designed and executed computational pipelines supporting strawberry and raspberry breeding programs",
+          "Collaborated with molecular biologists and breeders to integrate genomics into crop improvement"
+        ]
+      }
+    ],
+    "volunteer": null,
+    "education": [
+      {
+        "institution": "Johns Hopkins University",
+        "url": "https://jhu.edu",
+        "area": "Computer Science",
+        "studyType": "Ph.D.",
+        "startDate": "2017-08",
+        "endDate": "2021-12",
+        "thesis": "Pan-genomics and the structural diversity of plant genomes"
+      },
+      {
+        "institution": "University of California, Santa Cruz",
+        "url": "https://ucsc.edu",
+        "area": "Biomolecular Engineering",
+        "studyType": "Bachelor of Science",
+        "startDate": "2009-09",
+        "endDate": "2014-06"
+      }
+    ]
+    ,
+    "awards": null,
+    "certificates": null,
+    "publications": [
+      {
+        "name": "Solanum pan-genetics reveals paralogues as contingencies in crop engineering",
+        "publisher": "Nature",
+        "releaseDate": "2025",
+        "url": "https://doi.org/10.1038/s41586-025-08619-6"
+      },
+      {
+        "name": "Establishing Physalis as a new Solanaceae model system enables genetic reevaluation of the inflated calyx syndrome",
+        "publisher": "The Plant Cell",
+        "releaseDate": "2023",
+        "url": "https://doi.org/10.1093/plcell/koac305"
+      },
+      {
+        "name": "The complete sequence of a human genome",
+        "publisher": "Science",
+        "releaseDate": "2022",
+        "url": "https://doi.org/10.1126/science.abj6987"
+      },
+      {
+        "name": "Chasing perfection: validation and polishing strategies for telomere-to-telomere genome assemblies (first author)",
+        "publisher": "Nature Methods",
+        "releaseDate": "2022",
+        "url": "https://doi.org/10.1038/s41592-022-01440-3"
+      },
+      {
+        "name": "Automated assembly scaffolding using RagTag elevates a new tomato system for high-throughput genome editing (first author)",
+        "publisher": "Genome Biology",
+        "releaseDate": "2022",
+        "url": "https://doi.org/10.1186/s13059-022-02823-7"
+      },
+      {
+        "name": "Natural genetic diversity in tomato flavor genes",
+        "publisher": "Frontiers in Plant Science",
+        "releaseDate": "2021",
+        "url": "https://doi.org/10.3389/fpls.2021.642828"
+      },
+      {
+        "name": "The genetic and epigenetic landscape of the Arabidopsis centromeres (first author)",
+        "publisher": "Science",
+        "releaseDate": "2021",
+        "url": "https://doi.org/10.1126/science.abi7489"
+      },
+      {
+        "name": "Pan-genomics and the structural diversity of plant genomes (first author)",
+        "publisher": "Ph.D. Dissertation, Johns Hopkins University",
+        "releaseDate": "2021",
+        "url": "http://jhir.library.jhu.edu/handle/1774.2/66801"
+      },
+      {
+        "name": "Major Impacts of Widespread Structural Variation on Gene Expression and Crop Improvement in Tomato (first author)",
+        "publisher": "Cell",
+        "releaseDate": "2020",
+        "url": "https://doi.org/10.1016/j.cell.2020.05.021"
+      },
+      {
+        "name": "Chromosome-Scale Assembly of the Bread Wheat Genome Reveals Thousands of Additional Gene Copies (first author)",
+        "publisher": "Genetics",
+        "releaseDate": "2020",
+        "url": "https://doi.org/10.1534/genetics.120.303501"
+      },
+      {
+        "name": "A master regulator of regeneration (first author)",
+        "publisher": "Science",
+        "releaseDate": "2019",
+        "url": "https://doi.org/10.1126/science.aaw6258"
+      },
+      {
+        "name": "Duplication of a domestication locus neutralized a cryptic variant that caused a breeding barrier in tomato",
+        "publisher": "Nature Plants",
+        "releaseDate": "2019",
+        "url": "https://doi.org/10.1038/s41477-019-0422-z"
+      },
+      {
+        "name": "Accurate circular consensus long-read sequencing improves variant detection and assembly of a human genome",
+        "publisher": "Nature Biotechnology",
+        "releaseDate": "2019",
+        "url": "https://doi.org/10.1038/s41587-019-0217-9"
+      },
+      {
+        "name": "The bracteatus pineapple genome and domestication of clonally propagated crops",
+        "publisher": "Nature Genetics",
+        "releaseDate": "2019",
+        "url": "https://doi.org/10.1038/s41588-019-0506-8"
+      },
+      {
+        "name": "RaGOO: fast and accurate reference-guided scaffolding of draft genomes (first author)",
+        "publisher": "Genome Biology",
+        "releaseDate": "2019",
+        "url": "https://doi.org/10.1186/s13059-019-1829-6"
+      },
+      {
+        "name": "The genome sequence and transcriptome of Potentilla micrantha and their comparison to Fragaria vesca (the woodland strawberry)",
+        "publisher": "GigaScience",
+        "releaseDate": "2018",
+        "url": "https://doi.org/10.1093/gigascience/giy010"
+      }
+    ],
+    "skills": [
+      {
+        "name": "Google Cloud & Cloud Engineering",
+        "level": "Advanced",
+        "keywords": [
+          "Cloud Run",
+          "Cloud Functions",
+          "Compute Engine",
+          "Cloud Storage",
+          "BigQuery",
+          "Pub/Sub",
+          "Workflows",
+          "Cloud Scheduler",
+          "Vertex AI",
+          "Service Orchestration",
+          "Serverless Architecture",
+          "CI/CD",
+          "Cloud-native Design"
+        ]
+      },
+      {
+        "name": "Data Engineering & Analytics",
+        "level": "Advanced",
+        "keywords": [
+          "Python",
+          "Pandas",
+          "Polars",
+          "PySpark",
+          "SQL",
+          "NoSQL",
+          "Schema Design",
+          "ETL Pipelines",
+          "Data Modeling",
+          "Data Transformation",
+          "Scalable Platform Design"
+        ]
+      },
+      {
+        "name": "Software Engineering & Architecture",
+        "level": "Advanced",
+        "keywords": [
+          "Object-Oriented Programming",
+          "Domain-Driven Design",
+          "Test-Driven Development",
+          "Dependency Inversion",
+          "Service-Oriented Architecture",
+          "Event-Driven Architecture",
+          "API Development",
+          "Context Management"
+        ]
+      },
+      {
+        "name": "Genomics & Computational Biology",
+        "level": "Advanced",
+        "keywords": [
+          "Genome Assembly",
+          "Pan-genomics",
+          "Structural Variation",
+          "Gene Annotation",
+          "Repeat Annotation",
+          "RNA-seq",
+          "ChIP-seq",
+          "Hi-C",
+          "Variant Discovery",
+          "Gene Editing",
+          "Molecular Biology",
+          "Plant Biology",
+          "Genetics",
+          "Epigenetics",
+          "Somatic Mutations"
+        ]
+      },
+      {
+        "name": "Leadership & Technical Communication",
+        "level": "Advanced",
+        "keywords": [
+          "Mentorship",
+          "Professional Development",
+          "Technical Documentation",
+          "Notion",
+          "Miro",
+          "Jira",
+          "Adobe Illustrator"
+        ]
+      }
+    ],
+    "languages": [
+      {
+        "language": "English",
+        "fluency": "Native speaker"
+      },
+      {
+        "language": "Spanish",
+        "fluency": "Basic"
+      }
+    ],
+    "interests": [
+      {
+        "name": "Personal Interests",
+        "keywords": [
+          "Baseball",
+          "Digital electronics",
+          "Bass guitar",
+          "Guitar",
+          "South Indian cooking",
+          "Southeast Asian history (Vietnamese & Cambodian)"
+        ]
+      },
+      {
+        "name": "Professional Interests",
+        "keywords": [
+          "Computer networking",
+          "Cloud genomics applications"
+        ]
+      }
+    ]
+    ,
+    "references": [
+      {
+        "name": "Professor Michael Schatz",
+        "reference": "PhD Advisor, Bloomberg Distinguished Professor of Computer Science and Biology, JHU. mschatz@jhu.edu"
+      }
+    ],
+    "projects": [
+      {
+        "name": "Arkadia — IoT Home Environment Monitoring System",
+        "startDate": null,
+        "endDate": null,
+        "description": "Designed a containerized, microservices-based home environment monitoring system featuring real-time sensor readings, Redis caching, FastAPI endpoints, and a React frontend for visualization. Includes a custom BME280 client and demonstrates continuous data processing via a polling-based pipeline.",
+        "highlights": [
+          "Microservices architecture",
+          "Containerization with Docker",
+          "BME280 sensor integration",
+          "Redis caching",
+          "FastAPI API development",
+          "React frontend",
+          "Real-time data processing"
+        ],
+        "url": "https://michaelalonge.com/projects/arkadia"
+      }
+    ]
+  }

--- a/src/config/cv.json
+++ b/src/config/cv.json
@@ -36,12 +36,13 @@
       {
         "name": "Ohalo Genetics",
         "position": "Lead Software Engineer, Computational Biology",
+        "location": "Remote",
         "url": "https://ohalo.com",
         "startDate": "2025-03-16",
         "endDate": "Present",
         "summary": "Leading the design and development of Ohalo’s genomics data platform, enabling automated and scalable management of genomics data to support breeding, gene editing, and IP strategy. Serving as the company’s lead subject matter expert in genomics and bioinformatics, with an emphasis on scalable and accurate genotyping methods.",
         "highlights": [
-          "Architect and lead development of Ohalo’s genomics data platform for large-scale breeding and gene editing programs",
+          "Lead design and development of Ohalo’s genomics data platform for breeding and gene editing programs",
           "Manage and mentor a cross-functional team of software engineers and bioinformaticians",
           "Set strategic direction for genomics and bioinformatics in support of IP and product development"
         ]
@@ -49,6 +50,7 @@
       {
         "name": "Ohalo Genetics",
         "position": "Lead Computational Biologist",
+        "location": "Remote",
         "url": "https://ohalo.com",
         "startDate": "2021-12-06",
         "endDate": "2025-03-16",
@@ -62,6 +64,7 @@
       {
         "name": "Johns Hopkins University",
         "position": "Ph.D. Student, Computer Science",
+        "location": "Baltimore, MD",
         "url": "https://cs.jhu.edu",
         "startDate": "2017-08-31",
         "endDate": "2021-12-03",
@@ -74,6 +77,7 @@
       {
         "name": "Driscoll's",
         "position": "Research Associate I and II: Computational Biology",
+        "location": "Watsonville, CA",
         "url": "https://www.driscolls.com/",
         "startDate": "2014-11-01",
         "endDate": "2017-08-01",

--- a/src/config/cv.json
+++ b/src/config/cv.json
@@ -336,17 +336,18 @@
     "projects": [
       {
         "name": "Arkadia — IoT Home Environment Monitoring System",
-        "startDate": null,
-        "endDate": null,
+        "startDate": "2024-06-01",
+        "endDate": "2025-02-01",
         "description": "Designed a containerized, microservices-based home environment monitoring system featuring real-time sensor readings, Redis caching, FastAPI endpoints, and a React frontend for visualization. Includes a custom BME280 client and demonstrates continuous data processing via a polling-based pipeline.",
         "highlights": [
-          "Microservices architecture",
-          "Containerization with Docker",
-          "BME280 sensor integration",
-          "Redis caching",
-          "FastAPI API development",
-          "React frontend",
-          "Real-time data processing"
+          "microservices",
+          "Docker",
+          "BME280",
+          "Redis",
+          "FastAPI",
+          "React",
+          "real-time data",
+          "IoT"
         ],
         "url": "https://michaelalonge.com/projects/arkadia"
       }

--- a/src/config/cv.json
+++ b/src/config/cv.json
@@ -4,11 +4,11 @@
       "label": "Software Engineer | Computational Biologist | Team Lead",
       "image": "/images/profile.png",
       "email": "malonge11@gmail.com",
-      "phone": "+1 (831) 201-2788",
+      "phone": null,
       "url": "https://michaelalonge.com",
       "summary": "Software engineer and computational biologist with 10+ years of experience designing and leading scalable data platforms. Ph.D. in Computer Science from Johns Hopkins with a strong publication record in top journals including Nature, Science, and Cell. Skilled in cloud-native architecture, data engineering, and bioinformatics, with a proven ability to bridge genomics and software engineering to build reliable, production-ready systems for biotech.",
       "location": {
-        "address": "",
+        "address": null,
         "postalCode": "90036",
         "city": "Los Angeles",
         "countryCode": "US",
@@ -18,7 +18,7 @@
         {
           "network": "LinkedIn",
           "username": "michael-alonge",
-          "url": "https://www.linkedin.com/in/michael-alonge-1348a973/"
+          "url": "https://www.linkedin.com/in/michael-alonge"
         },
         {
           "network": "GitHub",

--- a/src/config/cv.json
+++ b/src/config/cv.json
@@ -117,97 +117,144 @@
         "name": "Solanum pan-genetics reveals paralogues as contingencies in crop engineering",
         "publisher": "Nature",
         "releaseDate": "2025",
-        "url": "https://doi.org/10.1038/s41586-025-08619-6"
+        "url": "https://doi.org/10.1038/s41586-025-08619-6",
+        "selected": null,
+        "firstAuthor": false
       },
       {
         "name": "Establishing Physalis as a new Solanaceae model system enables genetic reevaluation of the inflated calyx syndrome",
-        "publisher": "The Plant Cell",
+        "publisher": "The Plant Cell", 
         "releaseDate": "2023",
-        "url": "https://doi.org/10.1093/plcell/koac305"
+        "url": "https://doi.org/10.1093/plcell/koac305",
+        "selected": false,
+        "summary": null,
+        "firstAuthor": false
       },
       {
         "name": "The complete sequence of a human genome",
         "publisher": "Science",
         "releaseDate": "2022",
-        "url": "https://doi.org/10.1126/science.abj6987"
+        "url": "https://doi.org/10.1126/science.abj6987",
+        "selected": true,
+        "summary": "As a member of the Telomere-to-Telomere Consortium, I helped polish the initial CHM13 draft assembly to correct small and structural misassemblies. For example, I finished the telomere on the p-arm of chromosome 18.",
+        "firstAuthor": false
       },
       {
-        "name": "Chasing perfection: validation and polishing strategies for telomere-to-telomere genome assemblies (first author)",
+        "name": "Chasing perfection: validation and polishing strategies for telomere-to-telomere genome assemblies",
         "publisher": "Nature Methods",
         "releaseDate": "2022",
-        "url": "https://doi.org/10.1038/s41592-022-01440-3"
+        "url": "https://doi.org/10.1038/s41592-022-01440-3",
+        "selected": true,
+        "summary": "A companion paper to the CHM13 assembly paper, my colleagues and I describe our methods for polishing the initial draft assembly.",
+        "firstAuthor": true
       },
       {
-        "name": "Automated assembly scaffolding using RagTag elevates a new tomato system for high-throughput genome editing (first author)",
+        "name": "Automated assembly scaffolding using RagTag elevates a new tomato system for high-throughput genome editing",
         "publisher": "Genome Biology",
         "releaseDate": "2022",
-        "url": "https://doi.org/10.1186/s13059-022-02823-7"
+        "url": "https://doi.org/10.1186/s13059-022-02823-7",
+        "selected": true,
+        "summary": "I introduced RagTag, a general-purpose genome assembly scaffolding and improvement tool.",
+        "firstAuthor": true
       },
       {
         "name": "Natural genetic diversity in tomato flavor genes",
         "publisher": "Frontiers in Plant Science",
         "releaseDate": "2021",
-        "url": "https://doi.org/10.3389/fpls.2021.642828"
+        "url": "https://doi.org/10.3389/fpls.2021.642828",
+        "selected": false,
+        "summary": null,
+        "firstAuthor": false
       },
       {
-        "name": "The genetic and epigenetic landscape of the Arabidopsis centromeres (first author)",
+        "name": "The genetic and epigenetic landscape of the Arabidopsis centromeres",
         "publisher": "Science",
         "releaseDate": "2021",
-        "url": "https://doi.org/10.1126/science.abi7489"
+        "url": "https://doi.org/10.1126/science.abi7489",
+        "selected": true,
+        "summary": "I led the assembly of all five Columbia Arabidopsis thaliana centromeres—the first time ever for a plant species, to our knowledge.",
+        "firstAuthor": true
       },
       {
-        "name": "Pan-genomics and the structural diversity of plant genomes (first author)",
+        "name": "Pan-genomics and the structural diversity of plant genomes",
         "publisher": "Ph.D. Dissertation, Johns Hopkins University",
         "releaseDate": "2021",
-        "url": "http://jhir.library.jhu.edu/handle/1774.2/66801"
+        "url": "http://jhir.library.jhu.edu/handle/1774.2/66801",
+        "selected": false,
+        "summary": null,
+        "firstAuthor": true
       },
       {
-        "name": "Major Impacts of Widespread Structural Variation on Gene Expression and Crop Improvement in Tomato (first author)",
+        "name": "Major Impacts of Widespread Structural Variation on Gene Expression and Crop Improvement in Tomato",
         "publisher": "Cell",
         "releaseDate": "2020",
-        "url": "https://doi.org/10.1016/j.cell.2020.05.021"
+        "url": "https://doi.org/10.1016/j.cell.2020.05.021",
+        "selected": true,
+        "summary": "I led an effort to catalog and characterize structural variation in 100 tomato varieties using Oxford Nanopore sequencing. I led an analysis that found that breeding introgressions from wild material substantially altered the genome structure of modern varieties.",
+        "firstAuthor": true
       },
       {
-        "name": "Chromosome-Scale Assembly of the Bread Wheat Genome Reveals Thousands of Additional Gene Copies (first author)",
+        "name": "Chromosome-Scale Assembly of the Bread Wheat Genome Reveals Thousands of Additional Gene Copies",
         "publisher": "Genetics",
         "releaseDate": "2020",
-        "url": "https://doi.org/10.1534/genetics.120.303501"
+        "url": "https://doi.org/10.1534/genetics.120.303501",
+        "selected": false,
+        "summary": null,
+        "firstAuthor": true
       },
       {
-        "name": "A master regulator of regeneration (first author)",
+        "name": "A master regulator of regeneration",
         "publisher": "Science",
         "releaseDate": "2019",
-        "url": "https://doi.org/10.1126/science.aaw6258"
+        "url": "https://doi.org/10.1126/science.aaw6258",
+        "selected": false,
+        "summary": null,
+        "firstAuthor": true
       },
       {
         "name": "Duplication of a domestication locus neutralized a cryptic variant that caused a breeding barrier in tomato",
         "publisher": "Nature Plants",
         "releaseDate": "2019",
-        "url": "https://doi.org/10.1038/s41477-019-0422-z"
+        "url": "https://doi.org/10.1038/s41477-019-0422-z",
+        "selected": false,
+        "summary": null,
+        "firstAuthor": false
       },
       {
         "name": "Accurate circular consensus long-read sequencing improves variant detection and assembly of a human genome",
         "publisher": "Nature Biotechnology",
         "releaseDate": "2019",
-        "url": "https://doi.org/10.1038/s41587-019-0217-9"
+        "url": "https://doi.org/10.1038/s41587-019-0217-9",
+        "selected": true,
+        "summary": "I helped benchmark the accuracy of structural variant calls generated from PacBio HiFi sequencing.",
+        "firstAuthor": false
       },
       {
         "name": "The bracteatus pineapple genome and domestication of clonally propagated crops",
         "publisher": "Nature Genetics",
         "releaseDate": "2019",
-        "url": "https://doi.org/10.1038/s41588-019-0506-8"
+        "url": "https://doi.org/10.1038/s41588-019-0506-8",
+        "selected": false,
+        "summary": null,
+        "firstAuthor": false
       },
       {
-        "name": "RaGOO: fast and accurate reference-guided scaffolding of draft genomes (first author)",
+        "name": "RaGOO: fast and accurate reference-guided scaffolding of draft genomes",
         "publisher": "Genome Biology",
         "releaseDate": "2019",
-        "url": "https://doi.org/10.1186/s13059-019-1829-6"
+        "url": "https://doi.org/10.1186/s13059-019-1829-6",
+        "selected": false,
+        "summary": null,
+        "firstAuthor": true
       },
       {
         "name": "The genome sequence and transcriptome of Potentilla micrantha and their comparison to Fragaria vesca (the woodland strawberry)",
         "publisher": "GigaScience",
         "releaseDate": "2018",
-        "url": "https://doi.org/10.1093/gigascience/giy010"
+        "url": "https://doi.org/10.1093/gigascience/giy010",
+        "selected": false,
+        "summary": null,
+        "firstAuthor": false
       }
     ],
     "skills": [

--- a/src/content/homepage/-index.md
+++ b/src/content/homepage/-index.md
@@ -14,7 +14,7 @@ banner:
 projects:
   title: "Featured Projects"
   items:
-    - title: "Using BigQuery to analyze genetic variants at scale"
+    - title: "Using BigQuery to analyze genetic variants at scale (coming soon)"
       description: "This pipeline fetches or generates VCF files, converts them into Avro batches, and efficiently ingests them into BigQuery using custom schemas. Partitioning and clustering optimize storage and query performance for large-scale genomic datasets."
       icon: "database"
       links:
@@ -26,12 +26,12 @@ projects:
       links:
         - label: "Learn More"
           url: "/projects/arkadia"
-    - title: "Batch-Based Contig Alignment: Speeding Up Comparative Genomics"
-      description: "A resilient data pipeline must decompose large-scale tasks into smaller, more manageable units. Here I apply this principle to genomics, specifically for aligning genome assemblies to each other, including both technical details and scientific interpretation."
-      icon: "brain"
+    - title: "Building a Modern Resume with Astro: JSON Data, Print-Optimized CSS, and SEO Benefits"
+      description: "I built a modern resume system that combines Astro's static site generation with the JSON Resume standard and print-optimized CSS to create both an SEO-friendly web presence and recruiter-ready PDF downloads."
+      icon: "briefcase"
       links:
         - label: "Learn More"
-          url: "/projects/batch-alignment"
+          url: "/projects/cv-design"
 
 # Publications Section
 publications:

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -11,6 +11,7 @@ import cvData from "@/config/cv.json";
         <header id="title">
           <h1>{cvData.basics.name}</h1>
           <span class="subtitle">{cvData.basics.label}</span>
+          <p id="summary">{cvData.basics.summary}</p>
         </header>
         <section class="main-block">
           <h2>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -165,17 +165,22 @@ import cvData from "@/config/cv.json";
           <h1>
             Skills
           </h1>
-          <ul>
-            <li>Omnipresence</li>
-            <li>Anonymity</li>
-          </ul>
-          <ul>
-            <li>Ordinarity</li>
-            <li>No name rights</li>
-          </ul>
+          {cvData.skills.map((skill) => (
+            <div class="skill-category">
+              <h2 class="skill-name">{skill.name}</h2>
+              <ul>
+                {skill.keywords.map((keyword) => (
+                  <li>{keyword}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
         </div>
         <div class="side-block" id="disclaimer">
-          This r&eacute;sum&eacute; was wholly typeset with HTML/CSS &mdash; see <code>git.io/vVSYL</code>
+          <p>This r&eacute;sum&eacute; was typeset with HTML/CSS</p>
+          <p>Based on a project by <a href="git.io/vVSYL">MIN–ZHONG JOHN LU</a></p>
+          <p>Extended by Michael Alonge with help</p>
+          <p>from claude-4-sonnet
         </div>
       </aside>
       <div style="clear: both;"></div>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -1,7 +1,7 @@
 ---
 import Base from "@/layouts/Base.astro";
 import "@/styles/cv.css";
-import { FiBriefcase, FiFolder, FiBook, FiGlobe, FiLinkedin, FiMail, FiPhone, FiMapPin } from "react-icons/fi";
+import { FiBriefcase, FiFolder, FiBook, FiGlobe, FiLinkedin, FiMail, FiMapPin, FiGithub, FiBookOpen } from "react-icons/fi";
 import cvData from "@/config/cv.json";
 ---
 
@@ -155,12 +155,11 @@ import cvData from "@/config/cv.json";
       </section>
       <aside id="sidebar">
         <div class="side-block" id="contact">
-          <h1>
-            Contact Info
-          </h1>
           <ul>
             <li style="display: flex; align-items: center; gap: 4px;"><FiGlobe className="cv-icon" client:load /><a href={cvData.basics.url} target="_blank" rel="noopener noreferrer">{cvData.basics.url.replace('https://', '')}</a></li>
-            <li style="display: flex; align-items: center; gap: 4px;"><FiLinkedin className="cv-icon" client:load /><a href={cvData.basics.profiles.find(p => p.network === "LinkedIn")?.url} target="_blank" rel="noopener noreferrer">{cvData.basics.profiles.find(p => p.network === "LinkedIn")?.url.replace('https://www.', '')}</a></li>
+            <li style="display: flex; align-items: center; gap: 4px;"><FiLinkedin className="cv-icon" client:load /><a href={cvData.basics.profiles.find(p => p.network === "LinkedIn")?.url} target="_blank" rel="noopener noreferrer">{cvData.basics.profiles.find(p => p.network === "LinkedIn")?.username}</a></li>
+            <li style="display: flex; align-items: center; gap: 4px;"><FiGithub className="cv-icon" client:load /><a href={cvData.basics.profiles.find(p => p.network === "GitHub")?.url} target="_blank" rel="noopener noreferrer">{cvData.basics.profiles.find(p => p.network === "GitHub")?.username}</a></li>
+            <li style="display: flex; align-items: center; gap: 4px;"><FiBookOpen className="cv-icon" client:load /><a href={cvData.basics.profiles.find(p => p.network === "Google Scholar")?.url} target="_blank" rel="noopener noreferrer">Google Scholar</a></li>
             <li style="display: flex; align-items: center; gap: 4px;"><FiMail className="cv-icon" client:load /><a href={`mailto:${cvData.basics.email}`}>{cvData.basics.email}</a></li>
           </ul>
         </div>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -1,81 +1,49 @@
 ---
 import Base from "@/layouts/Base.astro";
 import "@/styles/cv.css";
-import { FiBriefcase, FiFolder, FiBook, FiGlobe, FiLinkedin, FiMail, FiPhone } from "react-icons/fi";
+import { FiBriefcase, FiFolder, FiBook, FiGlobe, FiLinkedin, FiMail, FiPhone, FiMapPin } from "react-icons/fi";
+import cvData from "@/config/cv.json";
 ---
 
 <Base title="CV">
   <div class="cv-container">
       <section id="main">
         <header id="title">
-          <h1>John Doe</h1>
-          <span class="subtitle">Plaintiff, defendant &amp; witness</span>
+          <h1>{cvData.basics.name}</h1>
+          <span class="subtitle">{cvData.basics.label}</span>
         </header>
         <section class="main-block">
           <h2>
-            <FiBriefcase className="cv-icon" /> Experiences
+            <FiBriefcase className="cv-icon" /> Professional Experience
           </h2>
-          <section class="blocks">
-            <div class="date">
-              <span>2015</span><span>present</span>
-            </div>
-            <div class="decorator">
-            </div>
-            <div class="details">
-              <header>
-                <h3>Some Position</h3>
-                <span class="place">Some Workplace</span>
-                <span class="location">(remote)</span>
-              </header>
-              <div>
-                <ul>
-                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit</li>
-                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec mi ante. Etiam odio eros, placerat eu metus id, gravida eleifend odio. Vestibulum dapibus pharetra odio, egestas ullamcorper ipsum congue ac. Maecenas viverra tortor eget convallis vestibulum. Donec pulvinar venenatis est, non sollicitudin metus laoreet sed. Fusce tincidunt felis nec neque aliquet porttitor</li>
-                </ul>
+          {cvData.work.map((job) => {
+            const startYear = new Date(job.startDate).getFullYear();
+            const endYear = job.endDate === "Present" ? "present" : new Date(job.endDate).getFullYear();
+            
+            return (
+              <section class="blocks">
+                <div class="date">
+                  <span>{startYear}</span><span>{endYear}</span>
                 </div>
-            </div>
-          </section>
-          <section class="blocks">
-            <div class="date">
-              <span>2014</span><span>2015</span>
-            </div>
-            <div class="decorator">
-            </div>
-            <div class="details">
-              <header>
-                <h3>Another Position</h3>
-                <span class="place">Some Workplace</span>
-                <span class="location">Some City, Some Country</span>
-              </header>
-              <div>
-                <ul>
-                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit</li>
-                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit</li>
-                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit</li>
-                </ul>
-              </div>
-            </div>
-          </section>
-          <section class="blocks">
-            <div class="date">
-              <span>2013</span><span>2014</span>
-            </div>
-            <div class="decorator">
-            </div>
-            <div class="details">
-              <header>
-                <h3>Yet Another Job Position</h3>
-                <span class="place">Some Workplace</span>
-                <span class="location">Some City, Some Country</span>
-              </header>
-              <div>
-                <ul>
-                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec mi ante. Etiam odio eros, placerat eu metus id, gravida eleifend odio</li>
-                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit</li>
-                </ul>
+                <div class="decorator">
                 </div>
-            </div>
-          </section>
+                <div class="details">
+                  <header>
+                    <h3>{job.position}</h3>
+                    <span class="place">{job.name}</span>
+                    <span class="location" style="display: flex; align-items: center; gap: 4px;"><FiMapPin className="cv-icon" />{job.location}</span>
+                  </header>
+                  <div>
+                    <ul>
+                      {job.highlights.map((highlight) => (
+                        <li>{highlight}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              </section>
+            );
+          })}
         </section>
         <section class="main-block">
           <h2>
@@ -215,10 +183,10 @@ import { FiBriefcase, FiFolder, FiBook, FiGlobe, FiLinkedin, FiMail, FiPhone } f
             Contact Info
           </h1>
           <ul>
-            <li><FiGlobe className="cv-icon" client:load /> johndoe.gtld</li>
-            <li><FiLinkedin className="cv-icon" client:load /> linkedin.com/in/john</li>
-            <li><FiMail className="cv-icon" client:load /> me@johndoe.gtld</li>
-            <li><FiPhone className="cv-icon" client:load /> 800.000.0000</li>
+            <li style="display: flex; align-items: center; gap: 4px;"><FiGlobe className="cv-icon" client:load /> {cvData.basics.url.replace('https://', '')}</li>
+            <li style="display: flex; align-items: center; gap: 4px;"><FiLinkedin className="cv-icon" client:load /> {cvData.basics.profiles.find(p => p.network === "LinkedIn")?.username}</li>
+            <li style="display: flex; align-items: center; gap: 4px;"><FiMail className="cv-icon" client:load /> {cvData.basics.email}</li>
+            <li style="display: flex; align-items: center; gap: 4px;"><FiPhone className="cv-icon" client:load /> {cvData.basics.phone}</li>
           </ul>
         </div>
         <div class="side-block" id="skills">

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -1,0 +1,243 @@
+---
+import Base from "@/layouts/Base.astro";
+import "@/styles/cv.css";
+import { FiBriefcase, FiFolder, FiBook, FiGlobe, FiLinkedin, FiMail, FiPhone } from "react-icons/fi";
+---
+
+<Base title="CV">
+  <div class="cv-container">
+      <section id="main">
+        <header id="title">
+          <h1>John Doe</h1>
+          <span class="subtitle">Plaintiff, defendant &amp; witness</span>
+        </header>
+        <section class="main-block">
+          <h2>
+            <FiBriefcase className="cv-icon" /> Experiences
+          </h2>
+          <section class="blocks">
+            <div class="date">
+              <span>2015</span><span>present</span>
+            </div>
+            <div class="decorator">
+            </div>
+            <div class="details">
+              <header>
+                <h3>Some Position</h3>
+                <span class="place">Some Workplace</span>
+                <span class="location">(remote)</span>
+              </header>
+              <div>
+                <ul>
+                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit</li>
+                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec mi ante. Etiam odio eros, placerat eu metus id, gravida eleifend odio. Vestibulum dapibus pharetra odio, egestas ullamcorper ipsum congue ac. Maecenas viverra tortor eget convallis vestibulum. Donec pulvinar venenatis est, non sollicitudin metus laoreet sed. Fusce tincidunt felis nec neque aliquet porttitor</li>
+                </ul>
+                </div>
+            </div>
+          </section>
+          <section class="blocks">
+            <div class="date">
+              <span>2014</span><span>2015</span>
+            </div>
+            <div class="decorator">
+            </div>
+            <div class="details">
+              <header>
+                <h3>Another Position</h3>
+                <span class="place">Some Workplace</span>
+                <span class="location">Some City, Some Country</span>
+              </header>
+              <div>
+                <ul>
+                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit</li>
+                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit</li>
+                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit</li>
+                </ul>
+              </div>
+            </div>
+          </section>
+          <section class="blocks">
+            <div class="date">
+              <span>2013</span><span>2014</span>
+            </div>
+            <div class="decorator">
+            </div>
+            <div class="details">
+              <header>
+                <h3>Yet Another Job Position</h3>
+                <span class="place">Some Workplace</span>
+                <span class="location">Some City, Some Country</span>
+              </header>
+              <div>
+                <ul>
+                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec mi ante. Etiam odio eros, placerat eu metus id, gravida eleifend odio</li>
+                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit</li>
+                </ul>
+                </div>
+            </div>
+          </section>
+        </section>
+        <section class="main-block">
+          <h2>
+            <FiFolder className="cv-icon" /> Selected Projects
+          </h2>
+          <section class="blocks">
+            <div class="date">
+              <span>2015</span><span>2016</span>
+            </div>
+            <div class="decorator">
+            </div>
+            <div class="details">
+              <header>
+                <h3>Some Project 1</h3>
+                <span class="place">Some workplace</span>
+              </header>
+              <div>
+                <ul>
+                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit</li>
+                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec mi ante. Etiam odio eros, placerat eu metus id, gravida eleifend odio. Vestibulum dapibus pharetra odio, egestas ullamcorper ipsum congue ac</li>
+                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec mi ante. Etiam odio eros, placerat eu metus id, gravida eleifend odio</li>
+                </ul>
+              </div>
+            </div>
+          </section>
+          <section class="blocks">
+            <div class="date">
+              <span>2014</span><span>2015</span>
+            </div>
+            <div class="decorator">
+            </div>
+            <div class="details">
+              <header>
+                <h3>Some Project 2</h3>
+                <span class="place">Some workplace</span>
+              </header>
+              <div>
+                <ul>
+                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec mi ante. Etiam odio eros, placerat eu metus id, gravida eleifend odio. Vestibulum dapibus pharetra odio, egestas ullamcorper ipsum congue ac. Maecenas viverra tortor eget convallis vestibulum. Donec pulvinar venenatis est, non sollicitudin metus laoreet sed. Fusce tincidunt felis nec neque aliquet porttitor</li>
+                </ul>
+              </div>
+            </div>
+          </section>
+          <section class="blocks">
+            <div class="date">
+              <span>2014</span>
+            </div>
+            <div class="decorator">
+            </div>
+            <div class="details">
+              <header>
+                <h3>Some Project 3</h3>
+                <span class="place">Some workplace</span>
+              </header>
+              <div>
+                <ul>
+                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec mi ante. Etiam odio eros, placerat eu metus id, gravida eleifend odio</li>
+                </ul>
+              </div>
+            </div>
+          </section>
+        </section>
+        <section class="main-block concise">
+          <h2>
+            <FiBook className="cv-icon" /> Education
+          </h2>
+          <section class="blocks">
+            <div class="date">
+              <span>2009</span><span>2014</span>
+            </div>
+            <div class="decorator">
+            </div>
+            <div class="details">
+              <header>
+                <h3>Ph.D. in Forty-Two Discovery</h3>
+                <span class="place">Inexistent University</span>
+                <span class="location">Some City, Some Country</span>
+              </header>
+              <div>Relationship of the number with the answer to life, the universe and everything</div>
+            </div>
+          </section>
+          <section class="blocks">
+            <div class="date">
+              <span>2005</span><span>2009</span>
+            </div>
+            <div class="decorator">
+            </div>
+            <div class="details">
+              <header>
+                <h3>LL.B. in H&aelig;matophagic Economics</h3>
+                <span class="place">Inexistent University</span>
+                <span class="location">Some City, Some Country</span>
+              </header>
+              <div>President's Scholarship</div>
+            </div>
+          </section>
+          <section class="blocks">
+            <div class="date">
+              <span>2005</span><span>2009</span>
+            </div>
+            <div class="decorator">
+            </div>
+            <div class="details">
+              <header>
+                <h3>B.S. in Existential Science (Double Major)</h3>
+                <span class="place">Inexistent University</span>
+                <span class="location">Some City, Some Country</span>
+              </header>
+              <div>President's Scholarship</div>
+            </div>
+          </section>
+          <section class="blocks">
+            <div class="date">
+            </div>
+            <div class="decorator">
+            </div>
+            <div class="details">
+              <header>
+                <h3>Massive Online Fee&ndash;Required Course (selective list)</h3>
+              </header>
+              <div class="concise">
+                <ul>
+                  <li>Introduction to something else</li>
+                  <li>Introduction to some more useless things</li>
+                  <li>Philosophy in practice</li>
+                  <li>Recursive research and its impact on recursive research</li>
+                  <li>Artificial politics</li>
+                </ul>
+              </div>
+            </div>
+          </section>
+        </section>
+      </section>
+      <aside id="sidebar">
+        <div class="side-block" id="contact">
+          <h1>
+            Contact Info
+          </h1>
+          <ul>
+            <li><FiGlobe className="cv-icon" client:load /> johndoe.gtld</li>
+            <li><FiLinkedin className="cv-icon" client:load /> linkedin.com/in/john</li>
+            <li><FiMail className="cv-icon" client:load /> me@johndoe.gtld</li>
+            <li><FiPhone className="cv-icon" client:load /> 800.000.0000</li>
+          </ul>
+        </div>
+        <div class="side-block" id="skills">
+          <h1>
+            Skills
+          </h1>
+          <ul>
+            <li>Omnipresence</li>
+            <li>Anonymity</li>
+          </ul>
+          <ul>
+            <li>Ordinarity</li>
+            <li>No name rights</li>
+          </ul>
+        </div>
+        <div class="side-block" id="disclaimer">
+          This r&eacute;sum&eacute; was wholly typeset with HTML/CSS &mdash; see <code>git.io/vVSYL</code>
+        </div>
+      </aside>
+      <div style="clear: both;"></div>
+  </div>
+</Base>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -50,62 +50,38 @@ import cvData from "@/config/cv.json";
           <h2>
             <FiFolder className="cv-icon" /> Selected Projects
           </h2>
-          <section class="blocks">
-            <div class="date">
-              <span>2015</span><span>2016</span>
-            </div>
-            <div class="decorator">
-            </div>
-            <div class="details">
-              <header>
-                <h3>Some Project 1</h3>
-                <span class="place">Some workplace</span>
-              </header>
-              <div>
-                <ul>
-                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit</li>
-                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec mi ante. Etiam odio eros, placerat eu metus id, gravida eleifend odio. Vestibulum dapibus pharetra odio, egestas ullamcorper ipsum congue ac</li>
-                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec mi ante. Etiam odio eros, placerat eu metus id, gravida eleifend odio</li>
-                </ul>
-              </div>
-            </div>
-          </section>
-          <section class="blocks">
-            <div class="date">
-              <span>2014</span><span>2015</span>
-            </div>
-            <div class="decorator">
-            </div>
-            <div class="details">
-              <header>
-                <h3>Some Project 2</h3>
-                <span class="place">Some workplace</span>
-              </header>
-              <div>
-                <ul>
-                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec mi ante. Etiam odio eros, placerat eu metus id, gravida eleifend odio. Vestibulum dapibus pharetra odio, egestas ullamcorper ipsum congue ac. Maecenas viverra tortor eget convallis vestibulum. Donec pulvinar venenatis est, non sollicitudin metus laoreet sed. Fusce tincidunt felis nec neque aliquet porttitor</li>
-                </ul>
-              </div>
-            </div>
-          </section>
-          <section class="blocks">
-            <div class="date">
-              <span>2014</span>
-            </div>
-            <div class="decorator">
-            </div>
-            <div class="details">
-              <header>
-                <h3>Some Project 3</h3>
-                <span class="place">Some workplace</span>
-              </header>
-              <div>
-                <ul>
-                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec mi ante. Etiam odio eros, placerat eu metus id, gravida eleifend odio</li>
-                </ul>
-              </div>
-            </div>
-          </section>
+          {cvData.projects.map((project) => {
+            const startYear = project.startDate ? new Date(project.startDate).getFullYear() : null;
+            const endYear = project.endDate ? new Date(project.endDate).getFullYear() : null;
+            
+            return (
+              <section class="blocks">
+                <div class="date">
+                  {startYear && <span>{startYear}</span>}
+                  {endYear && <span>{endYear}</span>}
+                </div>
+                <div class="decorator">
+                </div>
+                <div class="details">
+                  <header>
+                    <h3>{project.name}</h3>
+                  </header>
+                  <div>
+                    <p>{project.description}</p>
+                    {project.highlights && project.highlights.length > 0 && (
+                      <div class="highlights-inline">
+                        {project.highlights.map((highlight, index) => (
+                          <span class="highlight-item">
+                            {highlight}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </section>
+            );
+          })}
         </section>
         <section class="main-block concise">
           <h2>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -156,9 +156,9 @@ import cvData from "@/config/cv.json";
             Contact Info
           </h1>
           <ul>
-            <li style="display: flex; align-items: center; gap: 4px;"><FiGlobe className="cv-icon" client:load /> {cvData.basics.url.replace('https://', '')}</li>
+            <li style="display: flex; align-items: center; gap: 4px;"><FiGlobe className="cv-icon" client:load /><a href={cvData.basics.url} target="_blank" rel="noopener noreferrer">{cvData.basics.url.replace('https://', '')}</a></li>
             <li style="display: flex; align-items: center; gap: 4px;"><FiLinkedin className="cv-icon" client:load /><a href={cvData.basics.profiles.find(p => p.network === "LinkedIn")?.url} target="_blank" rel="noopener noreferrer">{cvData.basics.profiles.find(p => p.network === "LinkedIn")?.url.replace('https://www.', '')}</a></li>
-            <li style="display: flex; align-items: center; gap: 4px;"><FiMail className="cv-icon" client:load /> {cvData.basics.email}</li>
+            <li style="display: flex; align-items: center; gap: 4px;"><FiMail className="cv-icon" client:load /><a href={`mailto:${cvData.basics.email}`}>{cvData.basics.email}</a></li>
           </ul>
         </div>
         <div class="side-block" id="skills">

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -157,9 +157,8 @@ import cvData from "@/config/cv.json";
           </h1>
           <ul>
             <li style="display: flex; align-items: center; gap: 4px;"><FiGlobe className="cv-icon" client:load /> {cvData.basics.url.replace('https://', '')}</li>
-            <li style="display: flex; align-items: center; gap: 4px;"><FiLinkedin className="cv-icon" client:load /> {cvData.basics.profiles.find(p => p.network === "LinkedIn")?.username}</li>
+            <li style="display: flex; align-items: center; gap: 4px;"><FiLinkedin className="cv-icon" client:load /><a href={cvData.basics.profiles.find(p => p.network === "LinkedIn")?.url} target="_blank" rel="noopener noreferrer">{cvData.basics.profiles.find(p => p.network === "LinkedIn")?.url.replace('https://www.', '')}</a></li>
             <li style="display: flex; align-items: center; gap: 4px;"><FiMail className="cv-icon" client:load /> {cvData.basics.email}</li>
-            <li style="display: flex; align-items: center; gap: 4px;"><FiPhone className="cv-icon" client:load /> {cvData.basics.phone}</li>
           </ul>
         </div>
         <div class="side-block" id="skills">

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -87,71 +87,29 @@ import cvData from "@/config/cv.json";
           <h2>
             <FiBook className="cv-icon" /> Education
           </h2>
-          <section class="blocks">
-            <div class="date">
-              <span>2009</span><span>2014</span>
-            </div>
-            <div class="decorator">
-            </div>
-            <div class="details">
-              <header>
-                <h3>Ph.D. in Forty-Two Discovery</h3>
-                <span class="place">Inexistent University</span>
-                <span class="location">Some City, Some Country</span>
-              </header>
-              <div>Relationship of the number with the answer to life, the universe and everything</div>
-            </div>
-          </section>
-          <section class="blocks">
-            <div class="date">
-              <span>2005</span><span>2009</span>
-            </div>
-            <div class="decorator">
-            </div>
-            <div class="details">
-              <header>
-                <h3>LL.B. in H&aelig;matophagic Economics</h3>
-                <span class="place">Inexistent University</span>
-                <span class="location">Some City, Some Country</span>
-              </header>
-              <div>President's Scholarship</div>
-            </div>
-          </section>
-          <section class="blocks">
-            <div class="date">
-              <span>2005</span><span>2009</span>
-            </div>
-            <div class="decorator">
-            </div>
-            <div class="details">
-              <header>
-                <h3>B.S. in Existential Science (Double Major)</h3>
-                <span class="place">Inexistent University</span>
-                <span class="location">Some City, Some Country</span>
-              </header>
-              <div>President's Scholarship</div>
-            </div>
-          </section>
-          <section class="blocks">
-            <div class="date">
-            </div>
-            <div class="decorator">
-            </div>
-            <div class="details">
-              <header>
-                <h3>Massive Online Fee&ndash;Required Course (selective list)</h3>
-              </header>
-              <div class="concise">
-                <ul>
-                  <li>Introduction to something else</li>
-                  <li>Introduction to some more useless things</li>
-                  <li>Philosophy in practice</li>
-                  <li>Recursive research and its impact on recursive research</li>
-                  <li>Artificial politics</li>
-                </ul>
-              </div>
-            </div>
-          </section>
+          {cvData.education.map((edu) => {
+            const startYear = new Date(edu.startDate).getFullYear();
+            const endYear = new Date(edu.endDate).getFullYear();
+            
+            return (
+              <section class="blocks">
+                <div class="date">
+                  <span>{startYear}</span><span>{endYear}</span>
+                </div>
+                <div class="decorator">
+                </div>
+                <div class="details">
+                  <header>
+                    <h3>{edu.studyType} in {edu.area}</h3>
+                    <span class="place">{edu.institution}</span>
+                  </header>
+                  {edu.thesis && (
+                    <div>Thesis: {edu.thesis}</div>
+                  )}
+                </div>
+              </section>
+            );
+          })}
         </section>
       </section>
       <aside id="sidebar">

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -111,6 +111,44 @@ import cvData from "@/config/cv.json";
             );
           })}
         </section>
+        <section class="main-block">
+          <h2>
+            <FiBook className="cv-icon" /> Selected Publications
+          </h2>
+          {cvData.publications.filter(pub => pub.selected).map((publication) => {
+            const releaseYear = publication.releaseDate;
+            
+            return (
+              <section class="blocks">
+                <div class="date">
+                  <span>{releaseYear}</span>
+                </div>
+                <div class="decorator">
+                </div>
+                <div class="details">
+                  <header>
+                    <h3>
+                      {publication.name}
+                      {publication.firstAuthor && <span class="first-author-note"> (first author)</span>}
+                    </h3>
+                    <span class="place">{publication.publisher}</span>
+                  </header>
+                  <div>
+                    {publication.summary && publication.url && (
+                      <p>{publication.summary} — <a href={publication.url} target="_blank" rel="noopener noreferrer">{publication.url}</a></p>
+                    )}
+                    {publication.summary && !publication.url && (
+                      <p>{publication.summary}</p>
+                    )}
+                    {!publication.summary && publication.url && (
+                      <p><a href={publication.url} target="_blank" rel="noopener noreferrer">{publication.url}</a></p>
+                    )}
+                  </div>
+                </div>
+              </section>
+            );
+          })}
+        </section>
       </section>
       <aside id="sidebar">
         <div class="side-block" id="contact">

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -6,6 +6,9 @@ import cvData from "@/config/cv.json";
 ---
 
 <Base title="CV">
+  <div class="flex justify-center mb-4 print:hidden">
+    <button class="btn btn-outline-primary" onclick="window.print()">Print/Download Formatted CV</button>
+  </div>
   <div class="cv-container">
       <section id="main">
         <header id="title">
@@ -178,11 +181,13 @@ import cvData from "@/config/cv.json";
         </div>
         <div class="side-block" id="disclaimer">
           <p>This r&eacute;sum&eacute; was typeset with HTML/CSS</p>
-          <p>Based on a project by <a href="git.io/vVSYL">MIN–ZHONG JOHN LU</a></p>
+          <p>Based on a project by <a href="https://git.io/vVSYL">MIN–ZHONG JOHN LU</a></p>
           <p>Extended by Michael Alonge with help</p>
           <p>from claude-4-sonnet
         </div>
       </aside>
       <div style="clear: both;"></div>
   </div>
+  <div class="flex justify-center mb-4 print:hidden">
+    <button class="btn btn-outline-primary" onclick="window.print()">Print/Download Formatted CV</button>
 </Base>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,7 @@ import Base from "@/layouts/Base.astro";
 import { markdownify } from "@/lib/utils/textConverter";
 import type { CollectionEntry } from "astro:content";
 import { getEntry } from "astro:content";
-import { FiDatabase, FiGlobe, FiZap, FiBookOpen } from "react-icons/fi";
+import { FiDatabase, FiGlobe, FiZap, FiBookOpen, FiBriefcase } from "react-icons/fi";
 
 
 interface Homepage {
@@ -127,7 +127,7 @@ const { banner, projects, publications, cta } = homepage.data as Homepage;
                   <span class="text-2xl">
                     {project.icon === "database" && <FiDatabase className="h-7 w-7" />}
                     {project.icon === "chart" && <FiGlobe className="h-7 w-7" />}
-                    {project.icon === "brain" && <FiZap className="h-7 w-7" />}
+                    {project.icon === "briefcase" && <FiBriefcase className="h-7 w-7" />}
                   </span>
                 </div>
               </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,7 @@ import Base from "@/layouts/Base.astro";
 import { markdownify } from "@/lib/utils/textConverter";
 import type { CollectionEntry } from "astro:content";
 import { getEntry } from "astro:content";
-import { FiDatabase, FiGlobe, FiZap, FiBookOpen, FiBriefcase } from "react-icons/fi";
+import { FiDatabase, FiGlobe, FiBookOpen, FiBriefcase } from "react-icons/fi";
 
 
 interface Homepage {

--- a/src/styles/cv.css
+++ b/src/styles/cv.css
@@ -128,12 +128,10 @@
   
   #title {
     left: 0 !important;
-    text-align: center;
   }
   
   #main h2 {
     left: 0 !important;
-    text-align: center;
   }
 }
 
@@ -233,12 +231,14 @@
   
   .subtitle{
     font-size: 1rem;
+    font-weight: 400;
   }
   
   /* Print adjustment for subtitle */
   @media print {
     .subtitle{
       font-size: 8pt !important;
+      font-weight: 600 !important;
     }
   }
   
@@ -510,4 +510,14 @@
     font-family: "Source Code Pro";
     font-weight: 400;
     font-style: normal;
+  }
+
+  #summary{
+    font-size: 9pt;
+    margin-bottom: 1rem;
+    margin-top: 0.5rem;
+    text-transform: none;
+    width: 75%;
+    line-height: 1.2;
+
   }

--- a/src/styles/cv.css
+++ b/src/styles/cv.css
@@ -95,7 +95,7 @@
 #main{
   width: 75%;
   padding: 2rem 1rem 0 2rem;
-  font-size: 14px;
+  font-size: 7pt;
 }
 
 #sidebar{
@@ -411,6 +411,7 @@
   
   .details .place{
     float: left;
+    padding-bottom: 10px;
     font-size: 7.5pt;
   }
   
@@ -421,15 +422,7 @@
   .details div{
     clear: both;
   }
-  
-  .details .location::before{
-    display: inline-block;
-    position: relative;
-    right: 3pt;
-    top: 0.25pt;
-    content: "📍";
-    font-size: 8pt;
-  }
+
   
   /***** fine-tunes on the lists... *****/
   

--- a/src/styles/cv.css
+++ b/src/styles/cv.css
@@ -423,6 +423,17 @@
     clear: both;
   }
 
+  /* Reduce spacing between education header and thesis */
+  .main-block.concise .details header + div {
+    margin-top: 0.02in !important;
+    padding-top: 0 !important;
+  }
+
+  /* Reduce padding-bottom on institution name in education section */
+  .main-block.concise .details .place {
+    padding-bottom: 3px !important;
+  }
+
   
   /***** fine-tunes on the lists... *****/
   

--- a/src/styles/cv.css
+++ b/src/styles/cv.css
@@ -434,6 +434,19 @@
     padding-bottom: 3px !important;
   }
 
+  /* First author notation styling */
+  .first-author-note {
+    font-style: italic;
+    font-weight: normal;
+    color: #666;
+    font-size: 8pt;
+  }
+
+  /* Reduce padding-bottom on publisher name in publications section */
+  .main-block:not(.concise) .details .place {
+    padding-bottom: 3px !important;
+  }
+
   
   /***** fine-tunes on the lists... *****/
   

--- a/src/styles/cv.css
+++ b/src/styles/cv.css
@@ -1,0 +1,520 @@
+/* Print-specific styles */
+@page{
+    size: letter portrait;
+    margin: 0;
+  }
+
+/* CV-specific CSS variables */
+:root{
+  --page-width: 8.5in;
+  --page-height: 11in;
+  --main-width: 6.4in;
+  --sidebar-width: calc(var(--page-width) - var(--main-width));
+  --decorator-horizontal-margin: 0.2in;
+
+  --sidebar-horizontal-padding: 0.2in;
+
+  /* XXX: using px for very good precision control */
+  --decorator-outer-offset-top: 10px;
+  --decorator-outer-offset-left: -5.5px;
+  --decorator-border-width: 1px;
+  --decorator-outer-dim: 9px;
+  --decorator-border: 1px solid #ccc;
+
+  --row-blocks-padding-top: 5pt;
+  --date-block-width: 0.6in;
+
+  --main-blocks-title-icon-offset-left: -19pt;
+}
+
+/* Print styles - hide website header/footer and apply CV layout */
+@media print {
+  /* Hide website navigation elements but keep CV header */
+  body > header,
+  header[class],
+  .header,
+  nav,
+  footer,
+  .footer {
+    display: none !important;
+  }
+  
+  /* Ensure CV header (title section) remains visible */
+  #title,
+  #title h1,
+  .subtitle {
+    display: block !important;
+    visibility: visible !important;
+  }
+  
+  /* Reset body for print */
+  body {
+    width: var(--page-width) !important;
+    height: var(--page-height) !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    font-family: "Open Sans", sans-serif !important; 
+    font-weight: 300 !important;
+    line-height: 1.3 !important;
+    color: #444 !important;
+    hyphens: auto !important;
+    background: white !important;
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+  
+  /* Reset main content wrapper for print */
+  #main-content {
+    padding: 0 !important;
+    margin: 0 !important;
+    max-width: none !important;
+  }
+}
+  
+  h1, h2, h3{
+    margin: 0;
+    color: #000;
+  }
+  
+  li{
+    list-style-type: none;
+  }
+  
+/* Web layout styles */
+.cv-container {
+  max-width: 1200px;
+  margin: 2rem auto;
+  padding: 0;
+  background: white;
+  box-shadow: 0 0 20px rgba(0,0,0,0.1);
+  border-radius: 8px;
+  display: flex;
+  min-height: 100vh;
+}
+
+#main{
+  width: 75%;
+  padding: 2rem 1rem 0 2rem;
+  font-size: 14px;
+}
+
+#sidebar{
+  position: relative; /* for disclaimer */
+  width: 25%;
+  padding: 1.5rem 1rem;
+  background-color: #f2f2f2;
+  font-size: 16px;
+}
+
+/* Mobile responsive design */
+@media (max-width: 768px) {
+  .cv-container {
+    margin: 1rem;
+    padding: 1rem;
+    flex-direction: column;
+    min-height: auto;
+  }
+  
+  #main {
+    width: 100%;
+    padding: 1rem 0;
+  }
+  
+  #sidebar {
+    width: 100%;
+    margin-top: 2rem;
+    padding: 1rem;
+  }
+  
+  #title {
+    left: 0 !important;
+    text-align: center;
+  }
+  
+  #main h2 {
+    left: 0 !important;
+    text-align: center;
+  }
+}
+
+/* Print layout styles */
+@media print {
+  .cv-container {
+    max-width: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    background: white !important;
+    box-shadow: none !important;
+    border-radius: 0 !important;
+    display: block !important;
+    min-height: auto !important;
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+
+  #main{
+    float: left !important;
+    width: var(--main-width) !important;
+    padding: 0.25in 0.25in 0 0.25in !important;
+    font-size: 7pt !important;
+  }
+  
+  #sidebar{
+    float: right !important;
+    position: relative !important; /* for disclaimer */
+    width: var(--sidebar-width) !important;
+    height: var(--page-height) !important;
+    padding: 0.6in var(--sidebar-horizontal-padding) !important;
+    background-color: #f2f2f2 !important;
+    font-size: 8.5pt !important;
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+}
+  
+  /* main */
+  
+  /** big title **/
+  #title, h1, h2{
+    text-transform: uppercase;
+  }
+  
+  #title{
+    position: relative;
+    left: 1rem;
+    margin-bottom: 1rem;
+    line-height: 1.2;
+  }
+  
+  #title h1{
+    font-weight: 300;
+    font-size: 2.5rem;
+    line-height: 1.5;
+  }
+
+  /* Print adjustments for title */
+  @media print {
+    #title{
+      position: relative !important;
+      left: 0.55in !important;
+      margin-bottom: 0.3in !important;
+      line-height: 1.2 !important;
+    }
+    
+    #title h1{
+      font-weight: 300 !important;
+      font-size: 18pt !important;
+      line-height: 1.5 !important;
+    }
+    
+    /* Print adjustments for icons */
+    #main h2 > .cv-icon{
+      width: 12pt !important;
+      height: 12pt !important;
+      position: absolute !important;
+      left: var(--main-blocks-title-icon-offset-left) !important;
+      z-index: 1 !important;
+      color: #444 !important;
+      top: 1pt !important;
+    }
+    
+    #contact li > .cv-icon{
+      width: 9pt !important;
+      height: 9pt !important;
+      display: inline-block !important;
+      margin-right: 6pt !important;
+    }
+  }
+  
+  #title h1 strong{
+    margin: auto 2pt auto 4pt;
+    font-weight: 600;
+  }
+  
+  .subtitle{
+    font-size: 1rem;
+  }
+  
+  /* Print adjustment for subtitle */
+  @media print {
+    .subtitle{
+      font-size: 8pt !important;
+    }
+  }
+  
+  /*** categorial blocks ***/
+  
+  .main-block{
+    margin-top: 0.1in;
+  }
+  
+  #main h2{
+    position: relative;
+    top: 8px;
+    left: 4rem;
+    font-weight: 400;
+    font-size: 1.5rem;
+    color: #555;
+  }
+
+  /* Print adjustments for section headings */
+  @media print {
+    #main h2{
+      position: relative !important;
+      top: var(--row-blocks-padding-top) !important;
+      /* XXX: 0.5px for aligning fx printing */
+      left: calc((var(--date-block-width) + var(--decorator-horizontal-margin))) !important;
+      font-weight: 400 !important;
+      font-size: 11pt !important;
+      color: #555 !important;
+    }
+  }
+  
+  #main h2 > .cv-icon{
+    /* use absolute position to prevent icon's width from misaligning title */
+    /* assigning a fixed width here is no better due to needing to align decorator
+       line too */
+    position: absolute;
+    left: var(--main-blocks-title-icon-offset-left);
+    z-index: 1; /* over decorator line */
+    color: #444;
+    width: 12pt;
+    height: 12pt;
+  }
+  
+  #main h2::after{ /* extends the decorator line */
+    height: calc(var(--row-blocks-padding-top) * 2);
+    position: relative;
+    top: calc(-1 * var(--row-blocks-padding-top));
+    /* XXX: 0.5px for aligning fx printing */
+    left: calc(-1 * var(--decorator-horizontal-margin));
+    display: block;
+    border-left: var(--decorator-border);
+    z-index: 0;
+    line-height: 0;
+    font-size: 0;
+    content: ' ';
+  }
+  
+  /**** minor tweaks on the emoji icons ****/
+  #main h2 > .cv-icon{
+    top: 1pt;
+  }
+  
+  /**** individual row blocks (date - decorator - details) ****/
+  
+  .blocks{
+    display: flex;
+    flex-flow: row nowrap;
+  }
+  
+  .blocks > div{
+    padding-top: var(--row-blocks-padding-top);
+  }
+  
+  .date{
+    flex: 0 0 var(--date-block-width);
+    padding-top: calc(var(--row-blocks-padding-top) + 2.5pt) !important;
+    padding-right: var(--decorator-horizontal-margin);
+    font-size: 7pt;
+    text-align: right;
+    line-height: 1;
+  }
+  
+  .date span{
+    display: block;
+  }
+  
+  .date span:nth-child(2)::before{
+    position: relative;
+    top: 1pt;
+    right: 5.5pt;
+    display: block;
+    height: 10pt;
+    content: '|';
+  }
+  
+  .decorator{
+    flex: 0 0 0;
+    position: relative;
+    width: 2pt;
+    min-height: 100%;
+    border-left: var(--decorator-border);
+  }
+  
+  /*
+   * XXX: Use two filled circles to achieve the circle-with-white-border effect.
+   * The normal technique of only using one pseudo element and
+   * border: 1px solid white; style makes firefox erroneously either:
+   * 1) overflows the grayshade background (if no background-clip is set), or
+   * 2) shows decorator line which should've been masked by the white border
+   *
+   */
+  
+  .decorator::before{
+    position: absolute;
+    top: var(--decorator-outer-offset-top);
+    left: var(--decorator-outer-offset-left);
+    content: ' ';
+    display: block;
+    width: var(--decorator-outer-dim);
+    height: var(--decorator-outer-dim);
+    border-radius: calc(var(--decorator-outer-dim) / 2);
+    background-color: #fff;
+  }
+  
+  .decorator::after{
+    position: absolute;
+    top: calc(var(--decorator-outer-offset-top) + var(--decorator-border-width));
+    left: calc(var(--decorator-outer-offset-left) + var(--decorator-border-width));
+    content: ' ';
+    display: block;
+    width: calc(var(--decorator-outer-dim) - (var(--decorator-border-width) * 2));
+    height: calc(var(--decorator-outer-dim) - (var(--decorator-border-width) * 2));
+    border-radius: calc((var(--decorator-outer-dim) - (var(--decorator-border-width) * 2)) / 2);
+    background-color: #555;
+  }
+  
+  .blocks:last-child .decorator{ /* slightly shortens it */
+    margin-bottom: 0.25in;
+  }
+  
+  /***** fine-tunes on the details block where the real juice is *****/
+  
+  .details{
+    flex: 1 0 0;
+    padding-left: var(--decorator-horizontal-margin);
+    padding-top: calc(var(--row-blocks-padding-top) - 0.5pt) !important; /* not sure why but this is needed for better alignment */
+  }
+  
+  .details header{
+    color: #000;
+  }
+  
+  .details h3{
+    font-size: 9pt;
+  }
+  
+  .main-block:not(.concise) .details div{
+    margin: 0.18in 0 0.1in 0; 
+  }
+  
+  .main-block:not(.concise) .blocks:last-child .details div{
+    margin-bottom: 0;
+  }
+  
+  .main-block.concise .details div:not(.concise){
+    /* use padding to work around the fact that margin doesn't affect floated
+       neighboring elements */
+    padding: 0.05in 0 0.07in 0;
+  }
+  
+  .details .place{
+    float: left;
+    font-size: 7.5pt;
+  }
+  
+  .details .location{
+    float: right;
+  }
+  
+  .details div{
+    clear: both;
+  }
+  
+  .details .location::before{
+    display: inline-block;
+    position: relative;
+    right: 3pt;
+    top: 0.25pt;
+    content: "📍";
+    font-size: 8pt;
+  }
+  
+  /***** fine-tunes on the lists... *****/
+  
+  #main ul{
+    padding-left: 0.07in;
+    margin: 0.08in 0;
+  }
+  
+  #main li{
+    margin: 0 0 0.025in 0;
+  }
+  
+  /****** customize list symbol style ******/
+  #main li::before{
+    position: relative;
+    margin-left: -4.25pt;
+    content: '• ';
+  }
+  
+  .details .concise ul{
+    margin: 0 !important;
+    -webkit-columns: 2;
+    -moz-columns: 2;
+    columns: 2;
+  }
+  
+  .details .concise li{
+    margin: 0 !important;
+  }
+  
+  .details .concise li{
+    margin-left: 0 !important;
+  }
+  
+  
+  
+  /* sidebar */
+  
+  #sidebar h1{
+    font-weight: 400;
+    font-size: 11pt;
+  }
+  
+  .side-block{
+    margin-top: 0.5in; 
+  }
+  
+  #contact ul{
+    margin-top: 0.05in;
+    padding-left: 0;
+    font-family: "Source Code Pro";
+    font-weight: 400;
+    line-height: 1.75;
+  }
+  
+  #contact li > .cv-icon{
+    width: 9pt; /* for text alignment */
+    height: 9pt;
+    display: inline-block;
+    margin-right: 6pt;
+  }
+  
+  #skills{
+    line-height: 1.5;
+  }
+  
+  #skills ul{
+    margin: 0.05in 0 0.15in;
+    padding: 0;
+  }
+  
+  #disclaimer{
+    position: absolute;
+    bottom: var(--sidebar-horizontal-padding);
+    right: var(--sidebar-horizontal-padding);
+    font-size: 7.5pt;
+    font-style: italic;
+    line-height: 1.1;
+    text-align: right;
+    color: #777;
+  }
+  
+  #disclaimer code{
+    color: #666;
+    font-family: "Source Code Pro";
+    font-weight: 400;
+    font-style: normal;
+  }

--- a/src/styles/cv.css
+++ b/src/styles/cv.css
@@ -396,7 +396,7 @@
   }
   
   .main-block:not(.concise) .details div{
-    margin: 0.18in 0 0.1in 0; 
+    margin: 0.06in 0 0.1in 0; 
   }
   
   .main-block:not(.concise) .blocks:last-child .details div{
@@ -520,4 +520,43 @@
     width: 75%;
     line-height: 1.2;
 
+  }
+
+  /* Inline highlights for projects */
+  .highlights-inline {
+    margin-top: 0.08in;
+    line-height: 1.6;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .highlight-item {
+    display: inline-block;
+    background-color: #f8f9fa;
+    border: 1px solid #e9ecef;
+    border-radius: 4px;
+    padding: 2px 6px;
+    font-size: 6.5pt;
+    color: #495057;
+    white-space: nowrap;
+    line-height: 1.2;
+  }
+
+  /* Print-specific adjustments for tags */
+  @media print {
+    .highlights-inline {
+      margin-top: 0.06in !important;
+      line-height: 1.4 !important;
+      gap: 3px !important;
+    }
+    
+    .highlight-item {
+      background-color: #f8f9fa !important;
+      border: 1px solid #dee2e6 !important;
+      padding: 1.5px 4px !important;
+      font-size: 6pt !important;
+      -webkit-print-color-adjust: exact !important;
+      print-color-adjust: exact !important;
+    }
   }

--- a/src/styles/cv.css
+++ b/src/styles/cv.css
@@ -1,15 +1,21 @@
 /* Print-specific styles */
 @page{
     size: letter portrait;
-    margin: 0;
+    margin: 0.75in 0.5in;
   }
 
 /* CV-specific CSS variables */
 :root{
   --page-width: 8.5in;
   --page-height: 11in;
-  --main-width: 6.4in;
-  --sidebar-width: calc(var(--page-width) - var(--main-width));
+  --page-margin-top: 0.75in;
+  --page-margin-bottom: 0.75in;
+  --page-margin-left: 0.5in;
+  --page-margin-right: 0.5in;
+  --content-width: calc(var(--page-width) - var(--page-margin-left) - var(--page-margin-right));
+  --content-height: calc(var(--page-height) - var(--page-margin-top) - var(--page-margin-bottom));
+  --main-width: calc(var(--content-width) * 0.75);
+  --sidebar-width: calc(var(--content-width) * 0.25);
   --decorator-horizontal-margin: 0.2in;
 
   --sidebar-horizontal-padding: 0.2in;
@@ -150,19 +156,26 @@
     print-color-adjust: exact !important;
   }
 
+  /* Ensure sidebar background continues on multiple pages */
+  body {
+    background: linear-gradient(to right, white 0%, white var(--main-width), #f2f2f2 var(--main-width), #f2f2f2 100%) !important;
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+
   #main{
     float: left !important;
     width: var(--main-width) !important;
-    padding: 0.25in 0.25in 0 0.25in !important;
+    padding: 0 0.25in 0 0 !important;
     font-size: 7pt !important;
   }
   
   #sidebar{
     float: right !important;
-    position: relative !important; /* for disclaimer */
+    position: relative !important;
     width: var(--sidebar-width) !important;
-    height: var(--page-height) !important;
-    padding: 0.6in var(--sidebar-horizontal-padding) !important;
+    min-height: var(--content-height) !important;
+    padding: 0 var(--sidebar-horizontal-padding) !important;
     background-color: #f2f2f2 !important;
     font-size: 8.5pt !important;
     -webkit-print-color-adjust: exact !important;
@@ -239,6 +252,10 @@
     .subtitle{
       font-size: 8pt !important;
       font-weight: 600 !important;
+    }
+    
+    #summary{
+      width: 100% !important;
     }
   }
   
@@ -447,6 +464,19 @@
     padding-bottom: 3px !important;
   }
 
+  /* Skills section styling */
+  .skill-category {
+    margin-bottom: 0.15in;
+  }
+
+  .skill-name {
+    font-weight: 600;
+    font-size: 9pt;
+    margin-bottom: 0.05in;
+    color: #333;
+    text-transform: none;
+  }
+
   
   /***** fine-tunes on the lists... *****/
   
@@ -516,16 +546,15 @@
   #skills ul{
     margin: 0.05in 0 0.15in;
     padding: 0;
+    font-size: 7.5pt;
   }
   
   #disclaimer{
-    position: absolute;
-    bottom: var(--sidebar-horizontal-padding);
-    right: var(--sidebar-horizontal-padding);
+    margin-top: 0.3in;
     font-size: 7.5pt;
     font-style: italic;
     line-height: 1.1;
-    text-align: right;
+    text-align: center;
     color: #777;
   }
   


### PR DESCRIPTION
The CV page combines a few key components:

- A JSON file that contains my professional information following the [JSON Resume standard](https://jsonresume.org/)
- A HTML/CSS typeset resume template by [Min–Zhong John Lu](https://github.com/mnjul/html-resume?tab=readme-ov-file)
- The astroplate template

The resume data is stored in `src/config/cv.json` and is treated as a configuration. This decouples the resume data from the resume template. Then I extended and customized the HTML/CSS template provided by Min–Zhong John Lu in `src/styles/cv.css` and `src/pages/cv.astro` to create a modern, print-optimized resume. By default, the `cv` page behaves like a normal website page and all of my resume content is embedded directly in the page. However, I added a print button to the page that allows the user to print the resume to a formatted PDF.