### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,10 @@
+{
+  "name": "astroplate",
+  "install": "yarn install --frozen-lockfile",
+  "terminals": [
+    {
+      "name": "astro-dev",
+      "command": "yarn dev --host"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cloud Agent development environment configuration for this Astro + Tailwind + TypeScript site (`astroplate`).

The project uses the pinned package manager (`yarn@1.22.22`) and Node 20+ (the default Cloud Agent image ships Node 22, which satisfies the `astro v5.7` / `node v20.10+` requirements), so no custom Dockerfile is needed.

## Configuration

`.cursor/environment.json`:
- `install`: `yarn install --frozen-lockfile` — restores dependencies from the committed `yarn.lock` after checkout.
- `terminals.astro-dev`: `yarn dev --host` — runs the Astro dev server (port `4321`) with visible logs for the agent.

## Validation

- `yarn install --frozen-lockfile` completes and is idempotent (second run ~1s).
- `yarn check` (astro check) passes — "Folder in sync".
- `./scripts/validate-routes.sh` passes — 7 expected routes + sitemap validated.
- Astro dev server serves HTTP 200 on `/`, `/about`, `/contact`, `/cv`, `/projects`, `/publications`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd442d66-0758-492f-bc66-fd1c0fa17e89?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd442d66-0758-492f-bc66-fd1c0fa17e89&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

